### PR TITLE
Feature: Polybar screen brightness module

### DIFF
--- a/.config/polybar/config.ini
+++ b/.config/polybar/config.ini
@@ -53,4 +53,4 @@ bottom = true
 
 modules-left = host bspwm
 modules-center = datetime
-modules-right = updates alsa battery network powermenu
+modules-right = backlight updates alsa battery network powermenu

--- a/.config/polybar/config.ini
+++ b/.config/polybar/config.ini
@@ -51,6 +51,6 @@ enable-ipc = true
 wm-restack = bspwm
 bottom = true
 
-modules-left = host bspwm
+modules-left = start bspwm
 modules-center = datetime
 modules-right = backlight updates alsa battery network powermenu

--- a/.config/polybar/modules.ini
+++ b/.config/polybar/modules.ini
@@ -8,6 +8,59 @@
 ; the LICENSE file included with this project.
 ; ***************************************************
 
+[module/alsa]
+type = internal/alsa
+master-soundcard = default
+speaker-soundcard = default
+headphone-soundcard = default
+master-mixer = Master
+interval = 5
+format-volume = <label-volume>
+format-muted = <label-muted>
+label-volume = " %percentage%%"
+label-muted = " Muted"
+
+[module/backlight]
+type = internal/backlight
+format = <label>
+label = " %percentage%%"
+; Polybar can automatically detect the video card (Polybar version 3.7.0 or newer).
+; Usually for arch-based system, the main monitor is acpi_video0.
+; But if your monitor has a different card name, use the '$ls -1 /sys/class/backlight/'
+; command and add the value to 'card' variable.
+; card = acpi_video0
+use-actual-brightness = true
+poll-interval = 0
+; For security reasons, I turned off the 'scroll to change the brightness value'.
+; This requires the polybar to access the file `/sys/class/backlight/${self.card}/brightness`
+; which means the polybar needs sudo permissions to write to that file every time you scroll.
+enable-scroll = false
+
+[module/battery]
+type = internal/battery
+full-at = 100
+low-at = 20
+; Use the following command to list batteries and adapters:
+; $ ls -1 /sys/class/power_supply/
+battery = BAT0
+adapter = AC
+poll-interval = 1
+
+format-charging = <label-charging>
+format-charging-prefix = 
+format-charging-prefix-font = 2
+label-charging = "  %percentage%%"
+label-charging-font = 2
+
+format-discharging = <label-discharging>
+format-discharging-prefix = 
+format-discharging-prefix-font = 2
+label-discharging = " %percentage%%"
+label-discharging-font = 0
+
+label-full = " %percentage%% Charged"
+format-full-prefix-font = 1
+
 [module/bspwm]
 type = internal/bspwm
 pin-workspaces = true
@@ -35,64 +88,6 @@ ws-icon-3 = ws;
 ws-icon-4 = ws;
 ws-icon-default = 
 
-[module/backlight]
-type = internal/backlight
-format = <label>
-label = " %percentage%%"
-; Polybar can automatically detect the video card (Polybar version 3.7.0 or newer).
-; Usually for arch-based system, the main monitor is acpi_video0.
-; But if your monitor has a different card name, use the '$ls -1 /sys/class/backlight/'
-; command and add the value to 'card' variable.
-; card = acpi_video0
-use-actual-brightness = true
-poll-interval = 0
-; For security reasons, I turned off the 'scroll to change the brightness value'.
-; This requires the polybar to access the file `/sys/class/backlight/${self.card}/brightness`
-; which means the polybar needs sudo permissions to write to that file every time you scroll.
-enable-scroll = false
-
-[module/alsa]
-type = internal/alsa
-master-soundcard = default
-speaker-soundcard = default
-headphone-soundcard = default
-master-mixer = Master
-interval = 5
-format-volume = <label-volume>
-format-muted = <label-muted>
-label-volume = " %percentage%%"
-label-muted = " Muted"
-
-[module/battery]
-type = internal/battery
-full-at = 100
-low-at = 20
-; Use the following command to list batteries and adapters:
-; $ ls -1 /sys/class/power_supply/
-battery = BAT0
-adapter = AC
-poll-interval = 1
-
-; format-charging = <label-charging>
-; label-charging =  %percentage%%
-; format-discharging = <label-discharging>
-; label-discharging =  %percentage%%
-
-format-charging = <label-charging>
-format-charging-prefix = 
-format-charging-prefix-font = 2
-label-charging = "  %percentage%%"
-label-charging-font = 2
-
-format-discharging = <label-discharging>
-format-discharging-prefix = 
-format-discharging-prefix-font = 2
-label-discharging = " %percentage%%"
-label-discharging-font = 0
-
-label-full = " %percentage%% Charged"
-format-full-prefix-font = 1
-
 [module/datetime]
 type = internal/date
 interval = 60
@@ -100,6 +95,14 @@ format = <label>
 date = "%I:%M %p"
 time-alt = "%A, %d %B %Y - %H:%M"
 label = %date%%time%
+
+[module/host]
+type = custom/text
+format = <label>
+format-background = ${colors.background}
+format-foreground = ${colors.foreground}
+label = ""
+click-left = ~/.bin/appmenu
 
 [module/network]
 type = internal/network
@@ -110,14 +113,6 @@ format-connected = <label-connected>
 format-disconnected = <label-disconnected>
 label-connected = " %{A1:networkmanager_dmenu &:}%essid%%{A}"
 label-disconnected = " %{A1:networkmanager_dmenu &:}Disconnected%{A}"
-
-[module/host]
-type = custom/text
-format = <label>
-format-background = ${colors.background}
-format-foreground = ${colors.foreground}
-label = ""
-click-left = ~/.bin/appmenu
 
 [module/powermenu]
 type = custom/text

--- a/.config/polybar/modules.ini
+++ b/.config/polybar/modules.ini
@@ -39,7 +39,7 @@ enable-scroll = false
 [module/battery]
 type = internal/battery
 full-at = 100
-low-at = 20
+low-at = 25
 ; Use the following command to list batteries and adapters:
 ; $ ls -1 /sys/class/power_supply/
 battery = BAT0
@@ -58,7 +58,7 @@ format-discharging-prefix-font = 2
 label-discharging = " %percentage%%"
 label-discharging-font = 0
 
-label-full = " %percentage%% Charged"
+label-full = " %percentage%%"
 format-full-prefix-font = 1
 
 [module/bspwm]

--- a/.config/polybar/modules.ini
+++ b/.config/polybar/modules.ini
@@ -28,7 +28,7 @@ label = " %percentage%%"
 ; Usually for arch-based system, the main monitor is acpi_video0.
 ; But if your monitor has a different card name, use the '$ls -1 /sys/class/backlight/'
 ; command and add the value to 'card' variable.
-; card = acpi_video0
+card = acpi_video0
 use-actual-brightness = true
 poll-interval = 0
 ; For security reasons, I turned off the 'scroll to change the brightness value'.

--- a/.config/polybar/modules.ini
+++ b/.config/polybar/modules.ini
@@ -35,6 +35,22 @@ ws-icon-3 = ws;
 ws-icon-4 = ws;
 ws-icon-default = 
 
+[module/backlight]
+type = internal/backlight
+format = <label>
+label = " %percentage%%"
+; Polybar can automatically detect the video card (Polybar version 3.7.0 or newer).
+; Usually for arch-based system, the main monitor is acpi_video0.
+; But if your monitor has a different card name, use the '$ls -1 /sys/class/backlight/'
+; command and add the value to 'card' variable.
+; card = acpi_video0
+use-actual-brightness = true
+poll-interval = 0
+; For security reasons, I turned off the 'scroll to change the brightness value'.
+; This requires the polybar to access the file `/sys/class/backlight/${self.card}/brightness`
+; which means the polybar needs sudo permissions to write to that file every time you scroll.
+enable-scroll = false
+
 [module/alsa]
 type = internal/alsa
 master-soundcard = default

--- a/.config/polybar/modules.ini
+++ b/.config/polybar/modules.ini
@@ -96,14 +96,6 @@ date = "%I:%M %p"
 time-alt = "%A, %d %B %Y - %H:%M"
 label = %date%%time%
 
-[module/host]
-type = custom/text
-format = <label>
-format-background = ${colors.background}
-format-foreground = ${colors.foreground}
-label = ""
-click-left = ~/.bin/appmenu
-
 [module/network]
 type = internal/network
 interface = wlan0
@@ -121,6 +113,14 @@ format-background = ${colors.background}
 format-foreground = ${colors.alert}
 label = ""
 click-left = ~/.bin/powermenu
+
+[module/start]
+type = custom/text
+format = <label>
+format-background = ${colors.background}
+format-foreground = ${colors.foreground}
+label = ""
+click-left = ~/.bin/appmenu
 
 # This module will check for Pacman and AUR updates every 300 seconds (5 minutes) interval.
 # This module depends on the `pacman-contrib` (extra) package.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 - [ ] Polybar: Drop 'JetBrains Mono' for 'Inter' Font.
-- [ ] Polybar: Pacman update module.
-- [ ] Polybar: Brightness control module.
+- [X] Polybar: Pacman update module.
+- [X] Polybar: Brightness control module.
 - [ ] Rofi: Drop 'JetBrains Mono' for 'Inter' Font.
 - [ ] Rofi: Separate configuration for each launcher script.
 - [ ] Dunst: Fix color scheme to match the rest of the system


### PR DESCRIPTION
This pull brings a new feature to the bar where users can now see the percentage of their current screen brightness. This module does not (or at least not yet) provide direct brightness control by scrolling. 